### PR TITLE
fixing detection of 'sets'

### DIFF
--- a/chrome-extension/script.js
+++ b/chrome-extension/script.js
@@ -226,7 +226,8 @@ var SIO = {
     if (path.substring(0,22) !== 'https://soundcloud.com') {
       path = 'https://soundcloud.com' + path;
     }
-    if (path.indexOf("/sets/") > -1) {
+    var pathParts = path.split('/');
+    if (typeof pathParts[4] !== 'undefined' && pathParts[4] == "sets") {
       // don't make buttons for playlists/sets
       return false;
     }


### PR DESCRIPTION
Previous iteration was skipping drawButton() for tracks where the path had '/sets/' anywhere in it.   This was causing it also to erroneously skip individual tracks within a playlist since they have a "?in=officialfroxic/sets/fracture-ep" query parameter.   