### PR TITLE
remove hardcoding to coding.soundtrack.io

### DIFF
--- a/chrome-extension/script.js
+++ b/chrome-extension/script.js
@@ -28,7 +28,7 @@ var SIO = {
   /*  creates the iframe that we use for queueing */
   buildIframe: function() {
     var iframe = document.createElement('iframe');
-    iframe.src = 'https://coding.soundtrack.io/?iframe=true';
+    iframe.src = 'https://soundtrack.io/?iframe=true';
     iframe.id = 'soundtrack';
     iframe.height = 0;
     iframe.width = 0;


### PR DESCRIPTION
/playlist calls now will detect the room, so don't need to specify the subdomain for now.

(for future reference, specifying it here will defeat the detection of room, so this can be used to specify a room directly if we want to add that as a feature later)