### PR TITLE
Fix YouTube Performance Issues

### DIFF
--- a/chrome-extension/contentscript.js
+++ b/chrome-extension/contentscript.js
@@ -5,6 +5,12 @@ s.onload = function() {
 };
 (document.head||document.documentElement).appendChild(s);
 
+var h = document.createElement('script');
+h.src = chrome.extension.getURL('inject.js');
+h.onload = function() {
+  this.parentNode.removeChild(this);
+};
+(document.head||document.documentElement).appendChild(h);
 
 var j = document.createElement('script');
 j.src = chrome.extension.getURL('jquery-2.1.1.min.js');

--- a/chrome-extension/inject.js
+++ b/chrome-extension/inject.js
@@ -1,0 +1,54 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 erkserkserks
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+(function() {
+  // Override video element canPlayType() function
+  var videoElem = document.createElement('video');
+  var origCanPlayType = videoElem.canPlayType.bind(videoElem);
+  videoElem.__proto__.canPlayType = function(type) {
+    if (type === undefined) return '';
+    // If queried about webM/vp8/vp8 support, say we don't support them
+    if (type.indexOf('webm') != -1 ||
+      type.indexOf('vp8') != -1 ||
+      type.indexOf('vp9') != -1) {
+      return '';
+    }
+    // Otherwise, ask the browser
+    return origCanPlayType(type);
+  }
+
+  // Override media source extension isTypeSupported() function
+  var mse = window.MediaSource;
+  var origIsTypeSupported = mse.isTypeSupported.bind(mse);
+  mse.isTypeSupported = function(type) {
+    if (type === undefined) return '';
+    // If queried about webM/vp8/vp8 support, say we don't support them
+    if (type.indexOf('webm') != -1 ||
+      type.indexOf('vp8') != -1 ||
+      type.indexOf('vp9') != -1) {
+      return '';
+    }
+    // Otherwise, ask the browser
+    return origIsTypeSupported(type);
+  }
+})();

--- a/chrome-extension/manifest.json
+++ b/chrome-extension/manifest.json
@@ -25,7 +25,8 @@
           "https://*.youtube.com/*",
           "http://*.youtube.com/*"
         ],
-        "run_at": "document_start"
+        "run_at": "document_start",
+        "all_frames": true
     }],
     "web_accessible_resources": ["script.js", "inject.js", "jquery-2.1.1.min.js", "style.css"]
 }

--- a/chrome-extension/manifest.json
+++ b/chrome-extension/manifest.json
@@ -24,7 +24,8 @@
           "http://soundcloud.com/*",
           "https://*.youtube.com/*",
           "http://*.youtube.com/*"
-        ]
+        ],
+        "run_at": "document_start"
     }],
     "web_accessible_resources": ["script.js", "inject.js", "jquery-2.1.1.min.js", "style.css"]
 }

--- a/chrome-extension/manifest.json
+++ b/chrome-extension/manifest.json
@@ -26,5 +26,5 @@
           "http://*.youtube.com/*"
         ]
     }],
-    "web_accessible_resources": ["script.js", "jquery-2.1.1.min.js", "style.css"]
+    "web_accessible_resources": ["script.js", "inject.js", "jquery-2.1.1.min.js", "style.css"]
 }


### PR DESCRIPTION
This should force YouTube to use h264, which is hardware accelerated, rather than VP8 which often causes computers to initiate a takeoff sequence when an track falls back to YouTube for an audio source.